### PR TITLE
Add GPT4o-2024-08-06 to list of model options.

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -24,7 +24,8 @@
           <radio label="GPT-4" value="gpt-4" id="zotero-prefpane-__addonRef__-OPENAI_MODEL-0" />
           <radio label="GPT-4 Turbo" value="gpt-4-turbo" id="zotero-prefpane-__addonRef__-OPENAI_MODEL-1" />
           <radio label="GPT-4o" value="gpt-4o" id="zotero-prefpane-__addonRef__-OPENAI_MODEL-2" />
-          <radio label="GPT-4o mini" value="gpt-4o-mini" id="zotero-prefpane-__addonRef__-OPENAI_MODEL-3" />
+          <radio label="GPT-4o (2024-08-06)" value="gpt-4o-2024-08-06" id="zotero-prefpane-__addonRef__-OPENAI_MODEL-3" />
+          <radio label="GPT-4o mini" value="gpt-4o-mini" id="zotero-prefpane-__addonRef__-OPENAI_MODEL-4" />
         </radiogroup>
       </hbox>
       <hbox>


### PR DESCRIPTION
This version of GPT4o is 50% cheaper than the base one. $2.5/1M input tokens vs $5/1M input tokens.
It was released yesterday.

Which considering how many tokens something like adding a PDF to context could cost this could be quite significant.

![image](https://github.com/user-attachments/assets/ecfb72bc-29d0-484e-928f-4847cc5ed710)

I built this locally and it seems to work for me. The correct model API requests appeared on my OpenAI API dashboard.

![image](https://github.com/user-attachments/assets/cf884c20-c999-469e-9d99-b11c30045403)
![image](https://github.com/user-attachments/assets/0c0bfd99-51e7-4c9a-9444-1000e2b56621)
